### PR TITLE
feat(dev): `pre-commit-hooks-nix`: Add `pre-push` hook to automatically update Modrinth Modpack hash using `selfup`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .mypy_cache
 **/__pycache__
 .env
+.pre-commit-config.yaml

--- a/dev/flake.lock
+++ b/dev/flake.lock
@@ -1,5 +1,21 @@
 {
   "nodes": {
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1696426674,
+        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
     "flake-parts": {
       "inputs": {
         "nixpkgs-lib": "nixpkgs-lib"
@@ -35,6 +51,27 @@
       "original": {
         "owner": "numtide",
         "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "gitignore": {
+      "inputs": {
+        "nixpkgs": [
+          "pre-commit-hooks-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1709087332,
+        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
         "type": "github"
       }
     },
@@ -99,12 +136,35 @@
         "type": "github"
       }
     },
+    "pre-commit-hooks-nix": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "gitignore": "gitignore",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1742649964,
+        "narHash": "sha256-DwOTp7nvfi8mRfuL1escHDXabVXFGT1VlPD1JHrtrco=",
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "rev": "dcf5072734cb576d2b0c59b2ac44f5050b5eac82",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "flake-parts": "flake-parts",
         "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs",
         "poetry2nix": "poetry2nix",
+        "pre-commit-hooks-nix": "pre-commit-hooks-nix",
         "systems": "systems"
       }
     },

--- a/dev/flake.nix
+++ b/dev/flake.nix
@@ -21,30 +21,84 @@
         treefmt-nix.follows = "";
       };
     };
+
+    pre-commit-hooks-nix = {
+      url = "github:cachix/pre-commit-hooks.nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
-  outputs = inputs@{ flake-parts, systems, self, ... }: flake-parts.lib.mkFlake { inherit inputs; } ({
-    systems = import systems;
+  outputs = inputs @ {
+    flake-parts,
+    systems,
+    self,
+    ...
+  }:
+    flake-parts.lib.mkFlake {inherit inputs;} {
+      systems = import systems;
 
-    perSystem = { system, pkgs, ... }: {
-      _module.args.pkgs = import inputs.nixpkgs {
-        inherit system;
-        overlays = [ inputs.poetry2nix.overlays.default ];
-      };
+      imports = [
+        inputs.pre-commit-hooks-nix.flakeModule
+      ];
 
-      packages = {
-        generate-readme = pkgs.callPackage ../generate-readme { };
-      };
+      perSystem = {
+        config,
+        system,
+        pkgs,
+        inputs',
+        lib,
+        ...
+      }: {
+        _module.args.pkgs = import inputs.nixpkgs {
+          inherit system;
+          overlays = [inputs.poetry2nix.overlays.default];
+        };
 
-      devShells = {
-        default = pkgs.mkShell {
-          packages = with pkgs; [
-            nvfetcher
-            packwiz
-            poetry
-          ];
+        packages = {
+          generate-readme = pkgs.callPackage ../generate-readme {};
+          update-hash = pkgs.callPackage ../update-hash {};
+        };
+
+        pre-commit = {
+          settings = {
+            src = ./..;
+            hooks = {
+              update-hash = let
+                inherit (self.packages.${system}) update-hash;
+              in {
+                enable = true;
+                entry = "${lib.getExe update-hash} run";
+                fail_fast = true;
+                files = "(\\.toml$|\\.nix$|^flake.lock$)";
+                pass_filenames = false;
+                package = update-hash;
+                stages = ["pre-push"];
+              };
+
+              check-flake = {
+                enable = true;
+                entry = "nix flake check";
+                always_run = true;
+                pass_filenames = false;
+                after = ["update-hash"];
+                stages = ["pre-push"];
+              };
+            };
+          };
+        };
+
+        devShells = {
+          default = pkgs.mkShell {
+            packages = with pkgs; [
+              nvfetcher
+              packwiz
+              poetry
+            ];
+            shellHook = ''
+              ${config.pre-commit.installationScript}
+            '';
+          };
         };
       };
     };
-  });
 }

--- a/flake.nix
+++ b/flake.nix
@@ -12,24 +12,42 @@
     };
   };
 
-  outputs = inputs@{ flake-parts, systems, packwiz2nix, self, ... }: flake-parts.lib.mkFlake { inherit inputs; } ({ moduleWithSystem, ... }: {
-    systems = import systems;
+  outputs = inputs @ {
+    flake-parts,
+    systems,
+    packwiz2nix,
+    self,
+    ...
+  }:
+    flake-parts.lib.mkFlake {inherit inputs;} ({moduleWithSystem, ...}: {
+      systems = import systems;
 
-    perSystem = { system, pkgs, config, lib, ... }: {
-      packages =
-        let
+      perSystem = {
+        system,
+        pkgs,
+        config,
+        lib,
+        ...
+      }: {
+        packages = let
           packwiz2nixLib = inputs.packwiz2nix.lib.${system};
-        in
-        {
+          # These packs expects to be built using *Double Invocation*
+          # Without proper hash, the first build of any pack _will_ fail.
+          # Run `nix flake check ./?dir=dev&submodules=1` will give you the correct hash to assign below.
+          # When you've set the hash, the next build will return with a `/nix/store` location
+          # of the entry of the modpack, which will also be symlinked into `./result/`.
+          packwiz-server-hash = "sha256-JDdkCLeIdnHpTbEUA8WkH6G/0flbXBkHrYF9N/AlG8k=";
+          modrinth-pack-hash = "sha256-uBBfGeC+cOhaLHLUkx56K7qNhFplUTmeboZsbPbG3Eo=";
+        in {
           packwiz-server = packwiz2nixLib.fetchPackwizModpack {
             manifest = "${self}/pack.toml";
-            hash = "sha256-JDdkCLeIdnHpTbEUA8WkH6G/0flbXBkHrYF9N/AlG8k=";
+            hash = packwiz-server-hash;
             side = "server";
           };
 
           modrinth-pack = pkgs.callPackage ./nix/packwiz-modrinth.nix {
             src = self;
-            hash = "sha256-qPfIgqP6Xv4tt2p8xnDsspW540Q2We6nWUGYiJynyvM=";
+            hash = modrinth-pack-hash;
           };
 
           # Not used for anything right now
@@ -40,7 +58,7 @@
           # };
         };
 
-      checks = config.packages;
-    };
-  });
+        checks = config.packages;
+      };
+    });
 }

--- a/update-hash/default.nix
+++ b/update-hash/default.nix
@@ -1,0 +1,5 @@
+{pkgs}:
+pkgs.writeShellApplication rec {
+  name = "update-hash";
+  text = builtins.readFile ./${name}.bash;
+}

--- a/update-hash/update-hash.bash
+++ b/update-hash/update-hash.bash
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set +e -x
+
+validate_hash() {
+    hash_candidate="$1"
+
+    if [[ "$hash_candidate" =~ ^sha256-[A-Za-z0-9\\/+]{43}= ]]; then
+        return 0
+    fi
+    return 1
+}
+
+run() {
+
+    output="$(nix flake check --quiet 2>&1)"
+    nix_flake_check_exit_code="$?"
+    if [ $nix_flake_check_exit_code -ne 0 ]; then
+        new_hash=$(echo "$output" | grep "got:    sha256-" | tail -c 52)
+        old_hash=$(echo "$output" | grep "specified: sha256-" | tail -c 52)
+        if validate_hash "$old_hash" && validate_hash "$new_hash"; then
+            # Replace / with \/ in old_hash
+            existing_hash_match="${old_hash//\//\\/}" 
+            if [ "$2" == "--dry-run" ]; then
+                echo "dry-run: sed -i \"s;-hash = \"$existing_hash_match\";-hash = \"$new_hash\";g\" flake.nix"
+            else
+                sed -i "s;-hash = \"$existing_hash_match\";-hash = \"$new_hash\";g" flake.nix
+            fi
+            echo ./flake.nix: "$old_hash -> $new_hash"
+            exit 0
+        fi
+    else 
+        echo "$output"
+    fi
+    exit "$nix_flake_check_exit_code"
+}
+
+case "$1" in
+    run) run "$@";;
+    list) run --dry-run ;;
+esac
+echo "please provide action: run/list" && exit 1


### PR DESCRIPTION

#### Expected usage:
```bash
 ∴  git push origin feat/automatically-update-hash
update-hash..............................................................Failed
- hook id: update-hash
- files were modified by this hook

✓ flake.nix:39: sha256-U1jmiR4uxWCMeK0HLeVWYcxyjVzk1LdMZSs0xjA4zYo= => sha256-Y6mJ91pI0ZsPUNcIO4myYKrkB2+ENXe99+UAZYwz/N4=

1/1 items have been replaced
```
The `git push` will be aborted and you can amend or commit the new hash before pushing again. 

#### And when Modrinth Modpack hash is already up to date:
```bash
 ∴  git push origin feat/automatically-update-hash
update-hash..............................................................Passed
```

Also added some [comments](https://github.com/pedorich-n/MinecraftModpack/compare/main...Joaqim:feat/automatically-update-hash?expand=1#diff-206b9ce276ab5971a2489d75eb1b12999d4bf3843b7988cbe8d687cfde61dea0R34) to ./flake.nix, referring to `Double Invocation` for getting proper hash.
